### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ composer require pimcore/bundle-generator
 After that you should enable it using Pimcore Extension Manager on Admin or by using this command
 
 ```bash
-$ bin/console pimcore:bundle:enable PimcoreBundleGeneratorBundle
+$ bin/console pimcore:bundle:enable Pimcore/Bundle/BundleGeneratorBundle/PimcoreBundleGeneratorBundle
 ```
 
 Go to your terminal/command prompt, And you're ready to rock !


### PR DESCRIPTION
When I try to enable the bundle via 
```bash
bin/console pimcore:bundle:enable PimcoreBundleGeneratorBundle
``` 
it fails with:
```bash
[ERROR] Bundle "PimcoreBundleGeneratorBundle" is no valid bundle identifier
```

---

When I use this instead
```bash
bin/console pimcore:bundle:enable Pimcore/Bundle/BundleGeneratorBundle/PimcoreBundleGeneratorBundle
```
it works: 
```bash
[OK] Bundle "Pimcore\Bundle\BundleGeneratorBundle\PimcoreBundleGeneratorBundle" was successfully enabled
```