### PR TITLE
[Bug] Rename tests directory. 

### DIFF
--- a/src/Command/GenerateBundleCommand.php
+++ b/src/Command/GenerateBundleCommand.php
@@ -81,7 +81,7 @@ EOT
         $questionHelper = $this->getQuestionHelper();
 
         $bundle = $this->createBundleObject($input);
-        $bundle->setTestsDirectory($bundle->getTargetDirectory() . '/Tests');
+        $bundle->setTestsDirectory($bundle->getTargetDirectory() . '/tests');
 
         $questionHelper->writeSection($output, 'Bundle generation');
 

--- a/src/Model/BaseBundle.php
+++ b/src/Model/BaseBundle.php
@@ -43,7 +43,7 @@ class BaseBundle
         $this->targetDirectory = $targetDirectory;
         $this->configurationFormat = $configurationFormat;
         $this->isShared = $isShared;
-        $this->testsDirectory = $this->getTargetDirectory().'/Tests';
+        $this->testsDirectory = $this->getTargetDirectory().'/tests';
     }
 
     public function getNamespace()


### PR DESCRIPTION
Reneme the generated test directory from `Tests` to `tests` according to the flex structure. https://symfony.com/doc/current/setup/flex.html