### PR TITLE
chore: replace @reusable-workflows with @main

### DIFF
--- a/.github/workflows/new-php-style.yml
+++ b/.github/workflows/new-php-style.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   php-style:
-    uses: pimcore/workflows-collection-public/.github/workflows/reusable-php-style.yaml@reusable-workflows
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-php-style.yaml@main
     with:
       head_ref: ${{ github.ref_name }}
     secrets:


### PR DESCRIPTION
This PR replaces all occurrences of `@reusable-workflows` with `@main` across the repository.